### PR TITLE
SM-2274: Upgrade to Camel 2.13.0

### DIFF
--- a/assembly/src/main/filtered-resources/examples.xml
+++ b/assembly/src/main/filtered-resources/examples.xml
@@ -101,28 +101,34 @@
         <bundle>mvn:org.apache.servicemix.examples/camel-cxf-rest-route/${version}</bundle>
     </feature>
     <feature name="examples-cxf-ws-addressing" version="${version}" resolver="(obr)">
-        <feature version="${cxf.version}">cxf</feature>
+        <feature version="${cxf.version}">cxf-core</feature>
         <bundle dependency="true">mvn:org.springframework/org.springframework.beans/${spring.version}</bundle>
         <bundle dependency="true">mvn:commons-io/commons-io/${commons-io.version}</bundle>
         <bundle>mvn:org.apache.servicemix.examples/cxf-ws-addressing/${version}</bundle>
     </feature>
     <feature name="examples-cxf-ws-security-osgi" version="${version}" resolver="(obr)">
-        <feature version="${cxf.version}">cxf</feature>
+        <feature version="${cxf.version}">cxf-core</feature>
+        <feature version="${cxf.version}">cxf-ws-security</feature>
         <bundle dependency="true">mvn:org.springframework/org.springframework.beans/${spring.version}</bundle>
         <bundle>mvn:org.apache.servicemix.examples/cxf-ws-security-osgi/${version}</bundle>
     </feature>
     <feature name="examples-cxf-ws-security-blueprint" version="${version}" resolver="(obr)">
-        <feature version="${cxf.version}">cxf</feature>
+        <feature version="${cxf.version}">cxf-core</feature>
+        <feature version="${cxf.version}">cxf-ws-security</feature>
         <bundle>mvn:org.apache.servicemix.examples/cxf-ws-security-blueprint/${version}</bundle>
     </feature>
     <feature name="examples-cxf-ws-security-signature" version="${version}" resolver="(obr)">
-        <feature version="${cxf.version}">cxf</feature>
+        <feature version="${cxf.version}">cxf-core</feature>
+        <feature version="${cxf.version}">cxf-ws-security</feature>
+        <feature version="${cxf.version}">cxf-ws-rm</feature>
+        <bundle dependency="true">mvn:org.apache.cxf/cxf-bundle-compatible/${cxf.version}</bundle>
         <bundle dependency="true">mvn:org.springframework/org.springframework.beans/${spring.version}</bundle>
         <bundle dependency="true">mvn:commons-io/commons-io/${commons-io.version}</bundle>
         <bundle>mvn:org.apache.servicemix.examples/cxf-ws-security-signature/${version}</bundle>
     </feature>
     <feature name="examples-cxf-ws-rm" version="${version}" resolver="(obr)">
-        <feature version="${cxf.version}">cxf</feature>
+        <feature version="${cxf.version}">cxf-core</feature>
+        <feature version="${cxf.version}">cxf-ws-rm</feature>
         <bundle>mvn:org.apache.servicemix.examples/cxf-ws-rm/${version}</bundle>
     </feature>
     <feature name="examples-cxf-wsn-receive" version="${version}" resolver="(obr)">

--- a/itests/src/test/scala/org/apache/servicemix/itests/ExamplesIntegrationTests.scala
+++ b/itests/src/test/scala/org/apache/servicemix/itests/ExamplesIntegrationTests.scala
@@ -19,7 +19,7 @@ package org.apache.servicemix.itests
 import org.junit.runner.RunWith
 import org.junit.{Ignore, Test}
 import org.apache.camel.{Exchange, Processor}
-import org.ops4j.pax.exam.spi.reactors.{PerClass, ExamReactorStrategy}
+import org.ops4j.pax.exam.spi.reactors.{PerMethod, PerClass, ExamReactorStrategy}
 import org.ops4j.pax.exam.Configuration
 import org.ops4j.pax.exam.junit.PaxExam
 
@@ -109,9 +109,10 @@ class CamelExamplesTest extends ExamplesIntegrationTests {
 /**
  * Tests for the CXF examples
  */
+@ExamReactorStrategy(Array(classOf[PerMethod]))
 class CxfExamplesTest extends ExamplesIntegrationTests {
   @Test
-  def testCxfJaxRsExample = testWithFeature("examples-cxf-jaxrs", "camel-http") {
+  def testCxfJaxRsExample = testWithFeature(false,"examples-cxf-jaxrs", "camel-http") {
     expect { logging.containsMessage( _.contains("Setting the server's publish address to be /crm")) }
     // TODO: the service appears to be started, but the URLs are not accessible
     // assertTrue(httpGet("http://localhost:8181/cxf/crm/customerservice/customers/123").contains("<Customer><id>123</id>"))

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <activemq.version>5.9.0</activemq.version>
     <activiti.version>5.10</activiti.version>
-    <camel.version>2.12.3</camel.version>
+    <camel.version>2.13.0</camel.version>
     <cxf.version>2.7.10</cxf.version>
 
     <felix.obr.version>1.6.6</felix.obr.version>


### PR DESCRIPTION
- Upgraded the Camel version in pom
- Altered CXF examples features to load cxf-core instead cxf (since cxf is not amongst the boot features and will load spring)
- Moved CXF examples itests to separate containers due to logging interceptor registration problems (I assume this is because of the new camel shutdown policy)
