### PR TITLE
SM-2284: Intermittent test failure in CamelExamplesTest.testCamelDroolsExample

### DIFF
--- a/assembly/src/main/filtered-resources/examples.xml
+++ b/assembly/src/main/filtered-resources/examples.xml
@@ -86,7 +86,7 @@
         <feature version="${camel.version}">camel-blueprint</feature>
         <bundle>mvn:org.apache.servicemix.examples/camel-blueprint/${version}</bundle>
     </feature>
-    <feature name="examples-camel-drools" version="${version}" resolver="(obr)">
+    <feature name="examples-camel-drools" version="${version}">
         <feature version="${camel.version}">camel-jms</feature>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.drools/${drools.bundle.version}</bundle>
         <bundle>mvn:org.apache.servicemix.examples/camel-drools/${version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -167,11 +167,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-common-utilities</artifactId>
-        <version>${cxf.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-common-xsd</artifactId>
         <version>${cxf.version}</version>
       </dependency>
@@ -263,11 +258,6 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-testsupport</artifactId>
-        <version>${cxf.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-transports-common</artifactId>
         <version>${cxf.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Finally, after more than 20 builds still no error so I think this should be the fix:
- Removed obr resolver usage from features. Using it caused to the drools bundle to load slow and SMX could not find things like the namespaces handler, ending up trying online (which would redirect to a regular html site)
- Removed some non-existing managed dependencies I encountered during my search.
