### PR TITLE
SM-2267 Provide working configuration for activemq-web-console

### DIFF
--- a/assembly/src/main/resources/etc/org.apache.activemq.webconsole.cfg
+++ b/assembly/src/main/resources/etc/org.apache.activemq.webconsole.cfg
@@ -1,0 +1,23 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+webconsole.jms.url=${activemq.url}
+webconsole.jmx.url=service:jmx:rmi:///jndi/rmi://localhost:1099/karaf-${karaf.name}
+webconsole.jmx.user=smx
+webconsole.jmx.password=smx
+webconsole.jms.user=smx
+webconsole.jms.password=smx

--- a/assembly/src/main/resources/etc/system.properties
+++ b/assembly/src/main/resources/etc/system.properties
@@ -114,11 +114,7 @@ activemq.jmx.password=smx
 #
 # Activemq Webconsole configuration
 #
-webconsole.type=properties
-webconsole.jms.url=${activemq.url}
-webconsole.jmx.url=service:jmx:rmi:///jndi/rmi://localhost:1099/karaf-${karaf.name}
-webconsole.jmx.user=smx
-webconsole.jmx.password=smx
+# This configuration moved to org.apache.activemq.webconsole.cfg
 
 
 javax.xml.parsers.DocumentBuilderFactory=org.apache.xerces.jaxp.DocumentBuilderFactoryImpl


### PR DESCRIPTION
- Added org.apache.activemq.webconsole.cfg providing a working webconsole configuration
- Removed the old configuration from system.properties
