### PR TITLE
SM-2245: Upgrade to Pax Exam 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <xerces.version>2.11.0</xerces.version>
         <xml.api.version>2.11.0-20110622</xml.api.version>
         <xalan.version>2.7.1</xalan.version>
-        <pax.exam.version>3.4.0</pax.exam.version>
+        <pax.exam.version>3.5.0</pax.exam.version>
         <pax.url.version>1.3.7</pax.url.version>
         <postgresql.version>9.1-901</postgresql.version>
         <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
Updated and tested the version of Pax Exam to 3.5.0
