### PR TITLE
SM-2327: Refactor camel-cxf-rest example code

### DIFF
--- a/examples/camel/camel-cxf-rest/camel-cxf-rest-client/src/main/java/org/apache/servicemix/examples/camel/rest/client/Client.java
+++ b/examples/camel/camel-cxf-rest/camel-cxf-rest-client/src/main/java/org/apache/servicemix/examples/camel/rest/client/Client.java
@@ -20,7 +20,6 @@ package org.apache.servicemix.examples.camel.rest.client;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
@@ -31,11 +30,10 @@ import org.apache.servicemix.examples.camel.rest.model.Person;
 public class Client {
     private static final String PERSON_SERVICE_URL = "http://localhost:8989/rest/personservice/";
 
-
     public static void main(String[] args) {
         Client client = new Client();
         try {
-            client.postPerson(new Person(1,"John Smith",21));
+            client.postPerson(new Person(1, "John Smith", 21));
             client.getPerson(1);
             client.deletePerson(1);
         } catch (Exception e) {
@@ -45,7 +43,7 @@ public class Client {
 
     public void postPerson(Person person) throws Exception{
         System.out.println("\n### POST PERSON -> ");
-        URLConnection connection = connect(PERSON_SERVICE_URL+"person/post/");
+        HttpURLConnection connection = connect(PERSON_SERVICE_URL + "person/post/");
         connection.setDoOutput(true);
         connection.setRequestProperty("Content-Type", "application/xml");
 
@@ -58,19 +56,22 @@ public class Client {
         jaxbMarshaller.marshal(person, System.out);
         jaxbMarshaller.marshal(person, connection.getOutputStream());
 
-        System.out.println("\n### POST PERSON RESPONSE ");
-        System.out.println(IOUtils.toString(connection.getInputStream()));
+        System.out.println("\n### POST PERSON RESPONSE");
+        System.out.println("Status: " + connection.getResponseCode() +  " " + 
+                connection.getResponseMessage());
+        System.out.println("Location: " + connection.getHeaderField("Location"));
     }
 
     public void getPerson(int id) throws Exception{
-        String url = PERSON_SERVICE_URL+"person/get/"+id;
-        System.out.println("\n### GET PERSON WITH ID "+id+" FROM URL "+url);
+        String url = PERSON_SERVICE_URL + "person/get/" + id;
+        System.out.println("\n### GET PERSON WITH ID " + id + " FROM URL " + url);
         HttpURLConnection connection = connect(url);
         connection.setDoInput(true);
         InputStream stream = connection.getResponseCode() / 100 == 2 ?
                 connection.getInputStream() : connection.getErrorStream();
+        System.out.println("Status: " + connection.getResponseCode() + " " +
+                connection.getResponseMessage());
         System.out.println(IOUtils.toString(stream));
-
     }
 
     public void deletePerson(int id) throws Exception{
@@ -79,16 +80,16 @@ public class Client {
         HttpURLConnection connection = (HttpURLConnection) connect(url);
         connection.setRequestMethod("DELETE");
         connection.setDoInput(true);
-        InputStream stream = connection.getResponseCode() / 100 == 2 ?
-                connection.getInputStream() : connection.getErrorStream();
-        System.out.println(IOUtils.toString(stream));
-
+        System.out.println("Status: " + connection.getResponseCode() + " " +
+                connection.getResponseMessage());
+        if (connection.getResponseCode() / 100 != 2) {
+            System.out.println(IOUtils.toString(connection.getErrorStream()));
+        }
     }
 
     private HttpURLConnection connect(String url) throws Exception{
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         return connection;
     }
-
 
 }

--- a/examples/camel/camel-cxf-rest/camel-cxf-rest-route/src/main/java/org/apache/servicemix/examples/camel/rest/PersonService.java
+++ b/examples/camel/camel-cxf-rest/camel-cxf-rest-route/src/main/java/org/apache/servicemix/examples/camel/rest/PersonService.java
@@ -20,14 +20,13 @@ package org.apache.servicemix.examples.camel.rest;
 import org.apache.servicemix.examples.camel.rest.model.Person;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 
 // This could be an interface if CAMEL-6014 is fixed.
 
 @Path("/personservice/")
 public class PersonService {
-    @PathParam("id")
-    private String id;
-
+    
     @GET
     @Path("/person/get/{id}/")
     @Produces("application/xml")
@@ -37,15 +36,12 @@ public class PersonService {
 
     @POST
     @Path("/person/post")
-    @Produces("application/xml")
-    public Person putPerson(Person p) {
+    public Response putPerson(Person person) {
         return null;
     }
 
     @DELETE
     @Path("/person/delete/{id}")
-    @Produces("application/xml")
-    public Person deletePerson(@PathParam("id") String id) {
-        return null;
+    public void deletePerson(@PathParam("id") String id) {
     }
 }

--- a/examples/camel/camel-cxf-rest/camel-cxf-rest-service/src/main/java/org/apache/servicemix/examples/camel/rest/ServiceHandler.java
+++ b/examples/camel/camel-cxf-rest/camel-cxf-rest-service/src/main/java/org/apache/servicemix/examples/camel/rest/ServiceHandler.java
@@ -17,7 +17,9 @@
 
 package org.apache.servicemix.examples.camel.rest;
 
-import java.util.ArrayList;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -28,53 +30,48 @@ import org.apache.servicemix.examples.camel.rest.model.Person;
 
 public class ServiceHandler {
 
-    ArrayList<Person> persons = new ArrayList<Person>();
+    private Map<Integer, Person> persons = new HashMap<Integer, Person>();
 
     public void init(){
-        add(new Person(0,"test",100));
+        add(new Person(0, "Test Person", 100));
     }
 
-    private void add(Person person){
-        persons.add(person.getId(),person);
+    private Response add(Person person){
+        persons.put(person.getId(), person);
+        
+        return Response.created(URI.create("/personservice/person/get/"
+                + person.getId())).build();
     }
 
     private Person get(int id){
-        if (id < 0 || id >= persons.size()) {
+        Person person = persons.get(id);
+        if (person == null) {
             ResponseBuilder builder = Response.status(Status.NOT_FOUND);
             builder.entity("Person with ID " + id + " not found.");
             throw new WebApplicationException(builder.build());
         }
 
-       return persons.get(id);
+       return person;
     }
 
     private void delete(int id){
-        if (id < 0 || id >= persons.size()) {
+        if (persons.remove(id) == null) {
             ResponseBuilder builder = Response.status(Status.NOT_FOUND);
             builder.entity("Person with ID " + id + " not found.");
             throw new WebApplicationException(builder.build());
         }
-
-        persons.remove(id);
     }
 
     public Person getPerson(String id){
         return get(Integer.parseInt(id));
     }
 
-    public Person putPerson(Person person){
-        add(person);
-        return person;
+    public Response putPerson(Person person){
+        return add(person);
     }
 
-    public String deletePerson(int id){
+    public void deletePerson(int id){
         delete(id);
-        return new String();
     }
-
-
-
-
-
 
 }


### PR DESCRIPTION
- Use Map instead of List for storing person instances
- Follow REST principles by using appropriate HTTP response codes and
  response messages
- Follow JAX-RS programming model by returning Response instance where
  appropriate
- Remove unneeded fields and annotations

Signed-off-by: Gregor Zurowski gregor@zurowski.org
