### PR TITLE
SM-2313: Add error handling to camel-cxf-soap example

### DIFF
--- a/examples/camel/camel-cxf-soap/camel-cxf-soap-client/pom.xml
+++ b/examples/camel/camel-cxf-soap/camel-cxf-soap-client/pom.xml
@@ -35,6 +35,18 @@
             <groupId>org.apache.servicemix.examples</groupId>
             <artifactId>camel-cxf-soap-service</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- A dependency on a jaxb implementation will cause problems with the exec plugin classloader -->
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.examples</groupId>
+            <artifactId>camel-cxf-soap-route</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.examples</groupId>

--- a/examples/camel/camel-cxf-soap/camel-cxf-soap-client/src/main/java/org/apache/servicemix/examples/camel/soap/client/Client.java
+++ b/examples/camel/camel-cxf-soap/camel-cxf-soap-client/src/main/java/org/apache/servicemix/examples/camel/soap/client/Client.java
@@ -77,10 +77,10 @@ public class Client {
 
     public void deletePerson(int id) throws Exception{
         System.out.println("\n### DELETE PERSON WITH ID "+id);
-        String result = personService.deletePerson(id);
+        Person result = personService.deletePerson(id);
 
         System.out.println("\n### DELETE PERSON RESPONSE");
-        System.out.println(result);
+        printPerson(result);
     }
 
 

--- a/examples/camel/camel-cxf-soap/camel-cxf-soap-route/src/main/java/org/apache/servicemix/examples/camel/soap/PersonService.java
+++ b/examples/camel/camel-cxf-soap/camel-cxf-soap-route/src/main/java/org/apache/servicemix/examples/camel/soap/PersonService.java
@@ -18,15 +18,16 @@
 package org.apache.servicemix.examples.camel.soap;
 
 import org.apache.servicemix.examples.camel.soap.model.Person;
+import org.apache.servicemix.examples.camel.soap.model.PersonException;
 
 import javax.jws.WebParam;
 import javax.jws.WebService;
 
 @WebService(serviceName = "PersonService")
 public interface PersonService {
-    Person getPerson(@WebParam(name="id")int id);
+    Person getPerson(@WebParam(name="id")int id) throws PersonException;
 
     Person putPerson(Person person);
 
-    String deletePerson(@WebParam(name="id")int id);
+    Person deletePerson(@WebParam(name="id")int id) throws PersonException;
 }

--- a/examples/camel/camel-cxf-soap/camel-cxf-soap-service/pom.xml
+++ b/examples/camel/camel-cxf-soap/camel-cxf-soap-service/pom.xml
@@ -30,6 +30,13 @@
     <name>Apache ServiceMix :: Examples :: Camel CXF SOAP :: Service</name>
     <packaging>bundle</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/examples/camel/camel-cxf-soap/camel-cxf-soap-service/src/main/java/org/apache/servicemix/examples/camel/soap/model/PersonException.java
+++ b/examples/camel/camel-cxf-soap/camel-cxf-soap-service/src/main/java/org/apache/servicemix/examples/camel/soap/model/PersonException.java
@@ -1,0 +1,21 @@
+package org.apache.servicemix.examples.camel.soap.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.ws.WebFault;
+
+@WebFault(name="PersonException")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class PersonException extends RuntimeException {
+    private final String personid;
+    public PersonException(String message, String personId){
+        super(message);
+        this.personid = personId;
+    }
+
+    public String getPersonid(){
+        return this.personid;
+    }
+
+
+}


### PR DESCRIPTION
- Added a webfault to the soap service to handle simple request errors
- A little bit of refactoring