### PR TITLE
SM-2316: Add ksession configuration to camel-drools examples

### DIFF
--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/DroolsBlueprintBean.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/DroolsBlueprintBean.java
@@ -16,10 +16,7 @@
  */
 package org.apache.servicemix.examples.camel;
 
-import org.drools.KnowledgeBase;
-import org.drools.KnowledgeBaseConfiguration;
-import org.drools.KnowledgeBaseFactory;
-import org.drools.KnowledgeBaseFactoryService;
+import org.drools.*;
 import org.drools.builder.KnowledgeBuilder;
 import org.drools.builder.KnowledgeBuilderErrors;
 import org.drools.builder.KnowledgeBuilderFactory;
@@ -74,10 +71,16 @@ public class DroolsBlueprintBean {
     public static CommandExecutor createKnowledgeSession(KnowledgeBase kbase,GridNode node,String type,String name){
         CommandExecutor ksession;
 
-        if (type.equals("stateful"))
-            ksession = kbase.newStatefulKnowledgeSession();
-        else
-            ksession = kbase.newStatelessKnowledgeSession();
+        if (type.equals("stateful")) {
+
+            //Adding a configuration forces drools to use the current classloader (see issue SM-2316)
+            ksession = kbase.newStatefulKnowledgeSession(new SessionConfiguration(), null);
+
+        }else {
+
+            //Adding a configuration forces drools to use the current classloader (see issue SM-2316)
+            ksession = kbase.newStatelessKnowledgeSession(new SessionConfiguration());
+        }
 
         node.set(name,ksession);
         return ksession;

--- a/examples/camel/camel-drools/src/main/resources/META-INF/spring/camel-context.xml
+++ b/examples/camel/camel-drools/src/main/resources/META-INF/spring/camel-context.xml
@@ -40,7 +40,10 @@
         </drools:resources>
     </drools:kbase>
 
-    <drools:ksession id="ksession1" type="stateless" name="ksession1" kbase="kbase1" node="node1"/>
+    <drools:ksession id="ksession1" type="stateless" name="ksession1" kbase="kbase1" node="node1">
+        <!-- Adding a configuration forces drools to use the current classloader (see issue SM-2316) -->
+        <drools:configuration />
+    </drools:ksession>
 
     <bean id="droolsHelper" class="org.apache.servicemix.examples.camel.DroolsCommandHelper"/>
 


### PR DESCRIPTION
Adding an empty configuration when building the drools knowledge base, preventing drools from grabbing his default config with the old classloader.

Fix provided for example-camel-drools and example-camel-drools-blueprint.
