### PR TITLE
[SM-2707] Upgrade to Activiti 5.19.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
     <!-- Properties -->
     <properties>
         <activemq.version>5.12.1</activemq.version>
-        <activiti.version>5.17.0</activiti.version>
+        <activiti.version>5.19.0</activiti.version>
         <akka.version>2.3.9</akka.version>
         <aries.blueprint.core.version>1.4.4</aries.blueprint.core.version>
         <aries.proxy.version>1.0.4</aries.proxy.version>


### PR DESCRIPTION
Hi all,

This PR is related to:
https://issues.apache.org/jira/browse/SM-2707

Activiti is upgraded to 5.19.0 and not 5.18.0

Andrea