### PR TITLE
Don't use dot for Maven classifier 

### DIFF
--- a/activemq/activemq-service/pom.xml
+++ b/activemq/activemq-service/pom.xml
@@ -69,7 +69,7 @@
                                 <artifact>
                                     <file>${project.build.outputDirectory}/org.apache.servicemix.activemq.service.cfg</file>
                                     <type>cfg</type>
-                                    <classifier>activemq.service</classifier>
+                                    <classifier>activemq-service</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>

--- a/assembly/src/main/filtered-resources/features.xml
+++ b/assembly/src/main/filtered-resources/features.xml
@@ -28,7 +28,7 @@
         <bundle>mvn:org.apache.servicemix.activemq/org.apache.servicemix.activemq.service/${version}</bundle>
         <bundle>mvn:org.apache.servicemix.activemq/org.apache.servicemix.activemq.camel/${version}</bundle>
         <configfile finalname="/etc/org.apache.servicemix.activemq.service.cfg">
-            mvn:org.apache.servicemix.activemq/org.apache.servicemix.activemq.service/${project.version}/cfg/activemq.service
+            mvn:org.apache.servicemix.activemq/org.apache.servicemix.activemq.service/${project.version}/cfg/activemq-service
         </configfile>
     </feature>
 


### PR DESCRIPTION
Because it is not well supported by Maven and repositories like Nexus & Artifactory: they are not able to guess GAV.

See

* https://issues.apache.org/jira/browse/MINDEXER-49
* https://issues.sonatype.org/browse/NEXUS-6587
* https://www.jfrog.com/jira/browse/RTFACT-5971
* https://www.jfrog.com/jira/browse/RTFACT-8845