### PR TITLE
[SM-2850] Fix for test failure

### DIFF
--- a/logging/jms-appender/src/test/java/org/apache/servicemix/logging/jms/JMSAppenderTest.java
+++ b/logging/jms-appender/src/test/java/org/apache/servicemix/logging/jms/JMSAppenderTest.java
@@ -46,10 +46,16 @@ public class JMSAppenderTest extends CamelTestSupport {
     }
 
     @Before
-    public void setupBrokerAndAppender() throws Exception {
+    public void setupAppender() throws Exception {
         appender = new JMSAppender();
         appender.setDestinationName(EVENTS_TOPIC);
         appender.onBind(new ActiveMQConnectionFactory(broker.getVmConnectorURI().toString() + "?create=false"));
+    }
+    
+    @After
+    public void closeAppender() throws Exception {
+        appender.onUnbind(null);
+        appender.close();
     }
 
     @AfterClass


### PR DESCRIPTION
The reason for the test failures that sometimes happen might be that in @Before a new appender and ConnectionFactory is created for each test method but it is not closed. I added such cleanup code.