### PR TITLE
Assembly descriptor contains a *nix-specific root-relative-reference 

### DIFF
--- a/assemblies/apache-servicemix/src/main/resources/common-unix-bin.xml
+++ b/assemblies/apache-servicemix/src/main/resources/common-unix-bin.xml
@@ -20,7 +20,7 @@
         <!-- Cherry-pick files from the expanded Karaf distribution -->
         <fileSet>
             <directory>${project.build.directory}/assembly</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>${file.separator}</outputDirectory>
             <excludes>
                 <exclude>bin/**</exclude>
                 <exclude>setenv-*</exclude>
@@ -33,7 +33,7 @@
         <!-- Copy over bin/* scripts separately to get the correct file mode -->
         <fileSet>
             <directory>${project.build.directory}/assembly</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>bin/*</include>
             </includes>
@@ -42,7 +42,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/assembly</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>${file.separator}</outputDirectory>
             <includes>
                 <include>bin/*</include>
             </includes>


### PR DESCRIPTION
[INFO] Reading assembly descriptor: src/main/descriptors/unix-bin.xml
[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /
[ERROR] OS=Windows and the assembly descriptor contains a *nix-specific root-relative-reference (starting with slash) /

Solution in common-unix-bin.xml

Replace

<outputDirectory>/</outputDirectory>

with

<outputDirectory>${file.separator}</outputDirectory>