### PR TITLE
[SM-2954] Upgrade to Apache Camel 2.17.7

### DIFF
--- a/examples/drools/drools-camel-blueprint/pom.xml
+++ b/examples/drools/drools-camel-blueprint/pom.xml
@@ -33,7 +33,7 @@
 		</osgi.private.package>
 		<osgi.import.package>
 			org.slf4j;version="[1.6,2)",
-			org.apache.camel;version="[2.16,2.17)",
+			org.apache.camel;version="[2.17,2.18)",
 			org.kie.api.*;version="[6.0,7)",
 			org.kie.aries.blueprint.factorybeans;version="[6.0,7)",
 			org.kie.internal.command;version="[6.0,7)",

--- a/examples/drools/drools-camel-cxf-server/pom.xml
+++ b/examples/drools/drools-camel-cxf-server/pom.xml
@@ -40,7 +40,7 @@
             org.kie.api.event.rule;version="[6.0,7.0)",
             org.kie.api.command;version="[6.0,7.0)",
             org.kie.aries.blueprint.factorybeans;version="[6.0,7.0)",
-            org.apache.camel;version="[2.16,2.17)",
+            org.apache.camel;version="[2.17,2.18)",
 
             org.kie.internal.command;version="[6.0,7)",
             

--- a/itests/src/test/java/org/apache/servicemix/itests/ExamplesDrools6Test.java
+++ b/itests/src/test/java/org/apache/servicemix/itests/ExamplesDrools6Test.java
@@ -58,7 +58,7 @@ public class ExamplesDrools6Test extends ServiceMixDistroTest {
     @Test
     public void testDroolsCamelExample() throws Exception {
         try (Features features = install("examples-drools-camel-blueprint")) {
-            log.expectContains("Total 2 routes, of which 2 is started");
+            log.expectContains("Total 2 routes, of which 2 are started");
         }
     }
 

--- a/parent/assemblies-parent/pom.xml
+++ b/parent/assemblies-parent/pom.xml
@@ -39,9 +39,9 @@
 
         <!-- Assembly properties -->
         <activemq.version>5.14.5</activemq.version>
-        <camel.version>2.16.5</camel.version>
+        <camel.version>2.17.7</camel.version>
         <cxf.version>3.1.9</cxf.version>
-        <fasterxml.jackson.version>2.6.3</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.7.9</fasterxml.jackson.version>
         <geronimo-atinject.version>1.0</geronimo-atinject.version>
         <jodatime2.bundle.version>2.9</jodatime2.bundle.version>
         <karaf.version>4.0.9</karaf.version>


### PR DESCRIPTION
The upgrade of CXF to version 3.1.9 was already done for [issue 3228](https://issues.apache.org/jira/browse/SM-3228).

To make the itests work I also had to upgrade the version of Jacskon to 2.7.9.